### PR TITLE
Add OpenBao KMIP seal support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,40 +3,10 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -49,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -64,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -79,22 +49,61 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -105,9 +114,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.3"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
+checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -115,30 +124,14 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.30.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
+checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -155,46 +148,24 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bb8"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d8b8e1a22743d9241575c6ba822cf9c8fef34771c86ab7e477a4fbfd254e5"
+checksum = "457d7ed3f888dfd2c7af56d4975cade43c622f74bdcddfed6d4352f57acc6310"
 dependencies = [
  "futures-util",
  "parking_lot",
+ "portable-atomic",
  "tokio",
 ]
 
 [[package]]
 name = "bcder"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ffdaa8c6398acd07176317eb6c1f9082869dd1cc3fee7c72c6354866b928cc"
+checksum = "1f7c42c9913f68cf9390a225e81ad56a5c515347287eb98baa710090ca1de86d"
 dependencies = [
  "bytes",
  "smallvec",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.9.4",
- "cexpr",
- "clang-sys",
- "itertools",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.106",
- "which",
 ]
 
 [[package]]
@@ -205,27 +176,27 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.35"
+version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -234,19 +205,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -256,11 +218,10 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -270,21 +231,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -292,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -304,27 +254,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
@@ -404,39 +354,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.5.3"
+name = "data-encoding"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
+
+[[package]]
 name = "domain"
-version = "0.11.1-dev"
-source = "git+https://github.com/NLnetLabs/domain.git?branch=patches-for-nameshed-prototype#8d0025ebc865899e8fff584f8d5f106103101b4f"
+version = "0.11.1"
+source = "git+https://github.com/NLnetLabs/domain.git?branch=patches-for-nameshed-prototype#8239c9e58a3220588c4fc95b5824a0018c7147f5"
 dependencies = [
  "bumpalo",
  "bytes",
  "domain-macros",
- "hashbrown 0.14.5",
+ "hashbrown",
  "octseq",
  "openssl",
  "rand 0.8.5",
- "ring 0.17.14",
+ "ring",
  "secrecy 0.10.3",
  "time",
 ]
 
 [[package]]
 name = "domain-macros"
-version = "0.11.1-dev"
-source = "git+https://github.com/NLnetLabs/domain.git?branch=patches-for-nameshed-prototype#8d0025ebc865899e8fff584f8d5f106103101b4f"
+version = "0.11.1"
+source = "git+https://github.com/NLnetLabs/domain.git?branch=patches-for-nameshed-prototype#8239c9e58a3220588c4fc95b5824a0018c7147f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -444,12 +425,6 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "enum-display-derive"
@@ -463,14 +438,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-flags"
-version = "0.1.8"
+name = "enum-ordinalize"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3682d2328e61f5529088a02cd20bb0a9aeaeeeb2f26597436dd7d75d1340f8f5"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -481,19 +465,19 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.0"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
 name = "foreign-types"
@@ -541,20 +525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,47 +532,29 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasip2",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heck"
@@ -617,19 +569,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "hostname"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
@@ -638,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -662,39 +605,25 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "libc",
+ "hashbrown",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "itertools"
-version = "0.12.1"
+name = "itoa"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jobserver"
@@ -702,15 +631,15 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -719,12 +648,13 @@ dependencies = [
 [[package]]
 name = "kmip-protocol"
 version = "0.5.0"
-source = "git+https://github.com/NLnetLabs/kmip-protocol?branch=next#d57571f186e5809d35b31003e02c496141deee55"
+source = "git+https://github.com/neutron37/kmip-protocol?branch=feature%2Ftimestamp-support#0a8746be4d533344a3232c5e0bbe8657eedf3ab6"
 dependencies = [
  "bb8",
+ "bitflags 2.10.0",
  "cfg-if",
  "enum-display-derive",
- "enum-flags",
+ "enum-ordinalize",
  "hex",
  "kmip-ttlv",
  "log",
@@ -735,9 +665,10 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "tokio",
- "tokio-rustls 0.22.0",
+ "tokio-rustls",
  "tracing",
  "trait-set",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -774,10 +705,10 @@ dependencies = [
  "rand 0.9.2",
  "rcgen",
  "rpki",
- "rustls 0.23.31",
+ "rustls",
  "serde",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "toml",
 ]
 
@@ -788,32 +719,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
 
 [[package]]
 name = "libloading"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-link",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "listenfd"
@@ -828,41 +747,18 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "matchers"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
-dependencies = [
- "regex-automata",
-]
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "maybe-async"
@@ -872,14 +768,14 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memoffset"
@@ -897,41 +793,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "moka"
-version = "0.12.10"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+checksum = "a3dec6bd31b08944e08b58fd99373893a6c17054d6f3ea5006cc894f4f4eee2a"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
- "loom",
+ "equivalent",
  "parking_lot",
  "portable-atomic",
- "rustc_version",
  "smallvec",
  "tagptr",
- "thiserror",
  "uuid",
 ]
 
@@ -941,7 +826,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -959,12 +844,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.1"
+name = "num-bigint"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "windows-sys 0.52.0",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -972,6 +858,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -992,21 +887,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "octseq"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126c3ca37c9c44cec575247f43a3e4374d8927684f129d2beeb0d2cef262fe12"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1017,17 +912,17 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1044,14 +939,14 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -1061,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1071,15 +966,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1090,12 +985,12 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
-version = "3.0.5"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1118,9 +1013,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "powerfmt"
@@ -1138,29 +1033,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
@@ -1238,73 +1123,30 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "rcgen"
-version = "0.14.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0068c5b3cab1d4e271e0bb6539c87563c43411cad90b057b15c79958fbeb41f7"
+checksum = "3ec0a99f2de91c3cddc84b37e7db80e4d96b743e05607f647eb236fc0455907f"
 dependencies = [
  "pem",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "time",
+ "x509-parser",
  "yasna",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.4",
-]
-
-[[package]]
-name = "regex"
-version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -1317,7 +1159,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -1332,22 +1174,10 @@ dependencies = [
  "bytes",
  "chrono",
  "log",
- "ring 0.17.14",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
  "uuid",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1359,36 +1189,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.44"
+name = "rusticata-macros"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "bitflags 2.9.4",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
+ "nom",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64 0.13.1",
- "log",
- "ring 0.16.20",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1410,23 +1223,23 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "aws-lc-rs",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -1445,26 +1258,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
-]
 
 [[package]]
 name = "secrecy"
@@ -1486,55 +1283,57 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.17"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
 dependencies = [
  "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
+ "serde_core",
 ]
 
 [[package]]
@@ -1545,18 +1344,13 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
-
-[[package]]
-name = "slab"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -1566,19 +1360,13 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
@@ -1605,13 +1393,24 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "678faa00651c9eb72dd2020cbdf275d92eccb2400d568e419efdd64838145cb4"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -1634,40 +1433,32 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.42"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca967379f9d8eb8058d86ed467d81d03e81acd45757e4ca341c24affbe8e8e3"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -1679,15 +1470,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9108bb380861b07264b950ded55a44a14a4adc68b9f5efd85aafc3aa4d40a68"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7182799245a7264ce590b349d90338f1c1affad93d2639aed5f8f69c090b334c"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1695,64 +1486,50 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.19.1",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
-dependencies = [
- "rustls 0.23.31",
+ "rustls",
  "tokio",
 ]
 
 [[package]]
 name = "toml"
-version = "0.9.5"
+version = "0.9.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
@@ -1762,18 +1539,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.4"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7211ff1b8f0d3adae1663b7da9ffe396eabe1ca25f0b0bee42b0da29a9ddce93"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1784,24 +1561,24 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.2"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -1811,52 +1588,22 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex-automata",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -1872,15 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "untrusted"
@@ -1896,20 +1637,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -1924,45 +1659,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1970,56 +1692,33 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
- "wasm-bindgen-backend",
+ "syn 2.0.113",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "webpki-roots"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2045,32 +1744,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-link",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -2080,68 +1757,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
-]
-
-[[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core",
- "windows-link",
-]
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -2157,20 +1813,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2191,28 +1847,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2223,9 +1870,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2235,9 +1882,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2247,9 +1894,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -2259,9 +1906,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2271,9 +1918,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2283,9 +1930,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2295,9 +1942,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2307,24 +1954,42 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "x509-parser"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3e137310115a65136898d2079f003ce33331a6c4b0d51f1531d1be082b6425"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "yasna"
@@ -2337,26 +2002,26 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,9 @@ kmip-ttlv = { git = "https://github.com/NLnetLabs/kmip-ttlv", branch = "next", v
   "async-with-tokio",
   "high-level",
 ] }
-kmip = { git = "https://github.com/NLnetLabs/kmip-protocol", branch = "next", package = "kmip-protocol", version = "0.5", default-features = false, features = [
+# Use patched kmip-protocol with TimeStamp support for OpenBao compatibility
+# See: https://github.com/NLnetLabs/kmip-protocol/pull/42
+kmip = { git = "https://github.com/neutron37/kmip-protocol", branch = "feature/timestamp-support", package = "kmip-protocol", default-features = false, features = [
   "tls-with-tokio-rustls",
 ] }
 log = "0.4"

--- a/src/client_request_handler.rs
+++ b/src/client_request_handler.rs
@@ -5,24 +5,57 @@ use std::io::ErrorKind;
 use cryptoki::object::ObjectHandle;
 use cryptoki::types::AuthPin;
 use daemonbase::error::{ExitError, Failed};
+use kmip::ttlv::FastScanner;
 use kmip::types::common::Operation;
 use kmip::types::request::RequestMessage;
 use kmip::types::response::{BatchItem, ResultReason};
 use kmip_ttlv::PrettyPrinter;
 use log::{debug, error, info, log_enabled, warn};
 use moka::sync::Cache;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio_rustls::server::TlsStream;
 
 use crate::config::Config;
 use crate::kmip::operations::{
-    activate, create_key_pair, discover_versions, get, modify_attribute, query, sign, unknown,
+    activate, create_key_pair, decrypt, discover_versions, encrypt, get, get_attributes,
+    modify_attribute, query, sign, unknown,
 };
 use crate::kmip::util::{mk_err_batch_item, mk_kmip_hex_dump, mk_response};
 use crate::pkcs11::util::Pkcs11Pools;
 
 pub type HandleCache = Cache<String, ObjectHandle>;
+
+/// Read a complete TTLV message from the stream.
+/// Returns the raw bytes of the message.
+async fn read_ttlv_message<R: AsyncReadExt + Unpin>(reader: &mut R) -> std::io::Result<Vec<u8>> {
+    // TTLV header: 3 bytes tag + 1 byte type + 4 bytes length = 8 bytes
+    let mut header = [0u8; 8];
+    reader.read_exact(&mut header).await?;
+
+    // Extract length from bytes 4-7 (big endian)
+    let length = u32::from_be_bytes([header[4], header[5], header[6], header[7]]) as usize;
+
+    // Read the value bytes (padded to 8-byte boundary)
+    let padded_length = (length + 7) & !7;
+    let mut value = vec![0u8; padded_length];
+    reader.read_exact(&mut value).await?;
+
+    // Combine header and value into complete message
+    let mut message = Vec::with_capacity(8 + padded_length);
+    message.extend_from_slice(&header);
+    message.extend_from_slice(&value);
+
+    Ok(message)
+}
+
+/// Parse a RequestMessage from raw TTLV bytes using fast_scan.
+fn parse_request_fast(bytes: &[u8]) -> Result<RequestMessage, String> {
+    let mut scanner = FastScanner::new(bytes)
+        .map_err(|e| format!("FastScanner init error: {:?}", e))?;
+    RequestMessage::fast_scan(&mut scanner)
+        .map_err(|e| format!("FastScan error: {:?}", e))
+}
 
 pub async fn handle_client_requests(
     mut stream: TlsStream<TcpStream>,
@@ -30,7 +63,7 @@ pub async fn handle_client_requests(
     mut config: Config,
     mut pkcs11_pools: Pkcs11Pools,
 ) -> Result<(), ExitError> {
-    let reader_config = kmip::Config::new();
+    let _reader_config = kmip::Config::new();
     let tag_map = kmip::tag_map::make_kmip_tag_map();
     let enum_map = kmip::tag_map::make_kmip_enum_map();
     let pp = PrettyPrinter::new()
@@ -51,71 +84,83 @@ pub async fn handle_client_requests(
 
         let mut res_batch_items = vec![];
 
-        match kmip_ttlv::from_reader::<RequestMessage, _>(&mut stream, &reader_config).await {
-            Ok((req, _cap)) if !is_supported_protocol_version(&req) => {
-                // https://docs.oasis-open.org/kmip/spec/v1.2/os/kmip-spec-v1.2-os.html#_Toc409613599
-                // 11 Error Handling
-                // 11.1 General
-                //   Error Definition:
-                //     "Protocol major version mismatch"
-                //   Action:
-                //     "Response message containing a header and a Batch Item
-                //      without Operation, but with the Result Status field set to
-                //      Operation Failed"
-                res_batch_items.push(mk_err_batch_item(
-                    ResultReason::GeneralFailure,
-                    "Only KMIP protocol version <= 1.2 are supported".to_string(),
-                ));
-            }
-
-            Ok((req, req_bytes)) => {
-                if log_enabled!(log::Level::Debug) {
-                    let req_hex = mk_kmip_hex_dump(&req_bytes);
-                    let req_human = pp.to_string(&req_bytes);
-                    debug!("Request hex:\n{req_hex}\nRequest dump:\n{req_human}\n");
-                }
-
-                let (res, c, p) = tokio::task::spawn_blocking(move || {
-                    let r = process_request(&config, &pkcs11_pools, peer_addr, req);
-                    (r, config, pkcs11_pools)
-                })
-                .await
-                .map_err(|_| ExitError::from(Failed))?;
-
-                config = c;
-                pkcs11_pools = p;
-
-                res_batch_items.append(&mut res?);
-            }
-
-            Err((err, _cap)) if is_disconnection_err(&err) => {
-                // The client has gone, terminate this response stream processor.
+        // Read raw TTLV bytes from stream
+        let req_bytes = match read_ttlv_message(&mut stream).await {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == ErrorKind::UnexpectedEof || err.kind() == ErrorKind::ConnectionReset => {
+                // Client disconnected
                 break Ok(());
             }
+            Err(err) => {
+                error!("Error reading KMIP request from client {peer_addr}: {err}");
+                res_batch_items.push(mk_err_batch_item(
+                    ResultReason::GeneralFailure,
+                    format!("Unable to read KMIP request: {err}"),
+                ));
+                // Send error response and continue
+                let res_bytes = mk_response(res_batch_items);
+                if let Err(e) = stream.write_all(&res_bytes).await {
+                    warn!("Error sending response to {peer_addr}: {e}");
+                }
+                continue;
+            }
+        };
 
-            Err((err, res_bytes)) => {
-                let req_hex = mk_kmip_hex_dump(&res_bytes);
-                let req_human = pp.to_string(&res_bytes);
+        if log_enabled!(log::Level::Debug) {
+            let req_hex = mk_kmip_hex_dump(&req_bytes);
+            let req_human = pp.to_string(&req_bytes);
+            debug!("Request hex:\n{req_hex}\nRequest dump:\n{req_human}\n");
+        }
 
+        // Parse using fast_scan (handles operation-dependent payloads correctly)
+        let req = match parse_request_fast(&req_bytes) {
+            Ok(req) => req,
+            Err(err) => {
+                let req_hex = mk_kmip_hex_dump(&req_bytes);
+                let req_human = pp.to_string(&req_bytes);
                 error!(
                     "Error while parsing KMIP request from client {peer_addr}: {err}.\nRequest hex:\n{req_hex}\nRequest dump:\n{req_human}\n",
                 );
-
-                // https://docs.oasis-open.org/kmip/spec/v1.2/os/kmip-spec-v1.2-os.html#_Toc409613599
-                // 11 Error Handling
-                // 11.1 General
-                //   Error Definition:
-                //     "Message cannot be parsed"
-                //   Action:
-                //     "Response message containing a header and a Batch Item
-                //      without Operation, but with the Result Status field set to
-                //      Operation Failed"
                 res_batch_items.push(mk_err_batch_item(
                     ResultReason::GeneralFailure,
                     format!("Unable to parse KMIP TTLV request: {err}"),
                 ));
+                // Send error response and continue
+                let res_bytes = mk_response(res_batch_items);
+                if let Err(e) = stream.write_all(&res_bytes).await {
+                    warn!("Error sending response to {peer_addr}: {e}");
+                }
+                continue;
             }
         };
+
+        if !is_supported_protocol_version(&req) {
+            // https://docs.oasis-open.org/kmip/spec/v1.2/os/kmip-spec-v1.2-os.html#_Toc409613599
+            // 11 Error Handling
+            // 11.1 General
+            //   Error Definition:
+            //     "Protocol major version mismatch"
+            //   Action:
+            //     "Response message containing a header and a Batch Item
+            //      without Operation, but with the Result Status field set to
+            //      Operation Failed"
+            res_batch_items.push(mk_err_batch_item(
+                ResultReason::GeneralFailure,
+                "Only KMIP protocol version <= 1.2 are supported".to_string(),
+            ));
+        } else {
+            let (res, c, p) = tokio::task::spawn_blocking(move || {
+                let r = process_request(&config, &pkcs11_pools, peer_addr, req);
+                (r, config, pkcs11_pools)
+            })
+            .await
+            .map_err(|_| ExitError::from(Failed))?;
+
+            config = c;
+            pkcs11_pools = p;
+
+            res_batch_items.append(&mut res?);
+        }
 
         let res_bytes = mk_response(res_batch_items);
 
@@ -137,22 +182,41 @@ fn process_request(
 ) -> Result<Vec<BatchItem>, ExitError> {
     let authentication = req.header().authentication();
 
-    let Some(slot_label_id_or_index) = authentication.and_then(|auth| auth.username()) else {
-        return Ok(vec![mk_err_batch_item(
-            ResultReason::GeneralFailure,
-            "Requests must be authenticated with a username (PKCS#11 slot label/id/index)"
-                .to_string(),
-        )]);
-    };
+    // Get credentials from KMIP request or fall back to configured defaults
+    let (slot_label_id_or_index, pin): (String, String) =
+        match authentication.and_then(|auth| auth.username()) {
+            Some(slot) => {
+                // Username provided - password must also be provided (no mixing with defaults)
+                let Some(pin) = authentication.and_then(|auth| auth.password()) else {
+                    return Ok(vec![mk_err_batch_item(
+                        ResultReason::GeneralFailure,
+                        "Requests must be authenticated with a password (PKCS#11 pin)".to_string(),
+                    )]);
+                };
+                (slot.to_string(), pin.to_string())
+            }
+            None => {
+                // No username - check for configured defaults (both must be set)
+                // PIN can come from config file or DEFAULT_HSM_PIN env var
+                match (&config.default_slot, config.effective_default_pin()) {
+                    (Some(slot), Some(ref pin)) => {
+                        debug!(
+                            "Using configured default credentials for client {peer_addr} (slot: {slot})"
+                        );
+                        (slot.clone(), pin.clone())
+                    }
+                    _ => {
+                        return Ok(vec![mk_err_batch_item(
+                            ResultReason::GeneralFailure,
+                            "Requests must be authenticated with a username (PKCS#11 slot label/id/index)"
+                                .to_string(),
+                        )]);
+                    }
+                }
+            }
+        };
 
-    let Some(pin) = authentication.and_then(|auth| auth.password()) else {
-        return Ok(vec![mk_err_batch_item(
-            ResultReason::GeneralFailure,
-            "Requests must be authenticated with a password (PKCS#11 pin)".to_string(),
-        )]);
-    };
-
-    let pool = match pkcs11_pools.get(slot_label_id_or_index) {
+    let pool = match pkcs11_pools.get(&slot_label_id_or_index) {
         Ok(pool) => pool,
         Err(err) => {
             return Ok(vec![mk_err_batch_item(
@@ -202,7 +266,28 @@ fn process_request(
                         Operation::CreateKeyPair => create_key_pair::op(pkcs11conn, batch_item),
                         Operation::DiscoverVersions => discover_versions::op(batch_item),
                         Operation::Get => get::op(pkcs11conn, batch_item),
+                        Operation::GetAttributes => get_attributes::op(pkcs11conn, batch_item),
                         Operation::ModifyAttribute => modify_attribute::op(pkcs11conn, batch_item),
+                        Operation::Encrypt => {
+                            if config.enable_encrypt {
+                                encrypt::op(pkcs11conn, batch_item)
+                            } else {
+                                Err((
+                                    ResultReason::OperationNotSupported,
+                                    "Encrypt operation is disabled. Set enable_encrypt = true in config.".to_string(),
+                                ))
+                            }
+                        }
+                        Operation::Decrypt => {
+                            if config.enable_decrypt {
+                                decrypt::op(pkcs11conn, batch_item)
+                            } else {
+                                Err((
+                                    ResultReason::OperationNotSupported,
+                                    "Decrypt operation is disabled. Set enable_decrypt = true in config.".to_string(),
+                                ))
+                            }
+                        }
                         Operation::Sign => sign::op(pkcs11conn, batch_item),
                         _ => unknown::op(batch_item),
                     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,38 @@ pub struct Config {
 
     #[serde(flatten)]
     pub server_identity: ServerIdentity,
+
+    /// Default PKCS#11 slot label/id/index for clients that don't provide KMIP authentication.
+    ///
+    /// SECURITY NOTE: When set, any client that passes TLS authentication can access this slot
+    /// without providing KMIP-level credentials. Only use in single-tenant deployments where
+    /// TLS client certificate verification is sufficient for access control.
+    ///
+    /// Both default_slot and default_pin must be set for this feature to be active.
+    #[serde(default)]
+    pub default_slot: Option<String>,
+
+    /// Default PKCS#11 PIN for clients that don't provide KMIP authentication.
+    ///
+    /// Both default_slot and default_pin must be set for this feature to be active.
+    #[serde(default)]
+    pub default_pin: Option<String>,
+
+    /// Enable KMIP Encrypt operation.
+    ///
+    /// SECURITY NOTE: When enabled, clients can use keys to encrypt data.
+    /// This is required for OpenBao KMIP seal functionality.
+    /// Default: false (disabled for backwards compatibility)
+    #[serde(default)]
+    pub enable_encrypt: bool,
+
+    /// Enable KMIP Decrypt operation.
+    ///
+    /// SECURITY NOTE: When enabled, clients can use keys to decrypt data.
+    /// This is required for OpenBao KMIP seal functionality.
+    /// Default: false (disabled for backwards compatibility)
+    #[serde(default)]
+    pub enable_decrypt: bool,
 }
 
 #[derive(Clone, Deserialize)]
@@ -70,7 +102,16 @@ fn default_listen_port() -> u16 {
     5696
 }
 
+/// Environment variable name for default HSM PIN
+pub const DEFAULT_HSM_PIN_ENV: &str = "DEFAULT_HSM_PIN";
+
 impl Config {
+    /// Get the effective default PIN, checking environment variable if config is empty.
+    /// Environment variable DEFAULT_HSM_PIN takes precedence over config file.
+    pub fn effective_default_pin(&self) -> Option<String> {
+        std::env::var(DEFAULT_HSM_PIN_ENV).ok().or_else(|| self.default_pin.clone())
+    }
+
     /// Adds the basic arguments to a Clap command.
     ///
     /// Returns the command with the arguments added.
@@ -106,5 +147,86 @@ impl Config {
         let mut config = Self::from_toml(&toml_str, None::<PathBuf>).unwrap();
         config.log.apply_args(&args.log);
         Ok((config, args))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_config() -> Config {
+        Config::from_toml(
+            r#"
+            lib_path = "/usr/lib/softhsm/libsofthsm2.so"
+            "#,
+            None::<PathBuf>,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_default_credentials_not_set_by_default() {
+        let config = minimal_config();
+        assert!(config.default_slot.is_none());
+        assert!(config.default_pin.is_none());
+    }
+
+    #[test]
+    fn test_default_credentials_from_config() {
+        let config = Config::from_toml(
+            r#"
+            lib_path = "/usr/lib/softhsm/libsofthsm2.so"
+            default_slot = "test-slot"
+            default_pin = "1234"
+            "#,
+            None::<PathBuf>,
+        )
+        .unwrap();
+
+        assert_eq!(config.default_slot, Some("test-slot".to_string()));
+        assert_eq!(config.default_pin, Some("1234".to_string()));
+    }
+
+    // Note: Tests for env var override behavior (effective_default_pin with DEFAULT_HSM_PIN)
+    // are omitted because they require single-threaded execution due to shared global state.
+    // The env var logic is trivial (std::env::var check) and tested manually.
+    // Run with `cargo test -- --test-threads=1` if env var tests are needed.
+
+    #[test]
+    fn test_encrypt_decrypt_disabled_by_default() {
+        let config = minimal_config();
+        assert!(!config.enable_encrypt);
+        assert!(!config.enable_decrypt);
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_can_be_enabled() {
+        let config = Config::from_toml(
+            r#"
+            lib_path = "/usr/lib/softhsm/libsofthsm2.so"
+            enable_encrypt = true
+            enable_decrypt = true
+            "#,
+            None::<PathBuf>,
+        )
+        .unwrap();
+
+        assert!(config.enable_encrypt);
+        assert!(config.enable_decrypt);
+    }
+
+    #[test]
+    fn test_encrypt_only() {
+        let config = Config::from_toml(
+            r#"
+            lib_path = "/usr/lib/softhsm/libsofthsm2.so"
+            enable_encrypt = true
+            "#,
+            None::<PathBuf>,
+        )
+        .unwrap();
+
+        assert!(config.enable_encrypt);
+        assert!(!config.enable_decrypt);
     }
 }

--- a/src/kmip/operations/decrypt.rs
+++ b/src/kmip/operations/decrypt.rs
@@ -1,0 +1,61 @@
+use kmip::types::{
+    common::Operation,
+    request::{BatchItem, RequestPayload},
+    response::{
+        BatchItem as ResBatchItem, DecryptResponsePayload, ResponsePayload,
+        ResultReason, ResultStatus,
+    },
+};
+
+use crate::pkcs11::operations::decrypt::decrypt_data;
+use crate::pkcs11::pool::Pkcs11Connection;
+
+pub fn op(
+    pkcs11conn: Pkcs11Connection,
+    batch_item: &BatchItem,
+) -> Result<ResBatchItem, (ResultReason, String)> {
+    let RequestPayload::Decrypt(unique_identifier, cryptographic_parameters, data, iv_counter_nonce) = batch_item.request_payload() else {
+        return Err((
+            ResultReason::InvalidMessage,
+            "Batch item payload is not a Decrypt payload".to_string(),
+        ));
+    };
+
+    // UniqueIdentifier is required for this operation
+    let Some(id) = unique_identifier else {
+        return Err((
+            ResultReason::InvalidMessage,
+            "Decrypt requires a UniqueIdentifier".to_string(),
+        ));
+    };
+
+    // Convert IV from request if provided
+    let iv = iv_counter_nonce.as_ref().map(|v| v.as_bytes());
+
+    match decrypt_data(
+        pkcs11conn,
+        id,
+        cryptographic_parameters.as_ref(),
+        &data.0,
+        iv,
+    ) {
+        Ok(plaintext) => Ok(ResBatchItem {
+            operation: Some(Operation::Decrypt),
+            unique_batch_item_id: batch_item.unique_batch_item_id().cloned(),
+            result_status: ResultStatus::Success,
+            result_reason: None,
+            result_message: None,
+            payload: Some(ResponsePayload::Decrypt(DecryptResponsePayload {
+                unique_identifier: id.clone(),
+                data: plaintext,
+            })),
+            message_extension: None,
+        }),
+        Err(err) => Err((ResultReason::CryptographicFailure, err.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Integration tests would require a real PKCS#11 token
+}

--- a/src/kmip/operations/encrypt.rs
+++ b/src/kmip/operations/encrypt.rs
@@ -1,0 +1,62 @@
+use kmip::types::{
+    common::Operation,
+    request::{BatchItem, IVOrCounterOrNonce, RequestPayload},
+    response::{
+        BatchItem as ResBatchItem, EncryptResponsePayload, ResponsePayload,
+        ResultReason, ResultStatus,
+    },
+};
+
+use crate::pkcs11::operations::encrypt::encrypt_data;
+use crate::pkcs11::pool::Pkcs11Connection;
+
+pub fn op(
+    pkcs11conn: Pkcs11Connection,
+    batch_item: &BatchItem,
+) -> Result<ResBatchItem, (ResultReason, String)> {
+    let RequestPayload::Encrypt(unique_identifier, cryptographic_parameters, data, iv_counter_nonce) = batch_item.request_payload() else {
+        return Err((
+            ResultReason::InvalidMessage,
+            "Batch item payload is not an Encrypt payload".to_string(),
+        ));
+    };
+
+    // UniqueIdentifier is required for this operation
+    let Some(id) = unique_identifier else {
+        return Err((
+            ResultReason::InvalidMessage,
+            "Encrypt requires a UniqueIdentifier".to_string(),
+        ));
+    };
+
+    // Convert IV from request if provided
+    let iv = iv_counter_nonce.as_ref().map(|v| v.as_bytes());
+
+    match encrypt_data(
+        pkcs11conn,
+        id,
+        cryptographic_parameters.as_ref(),
+        &data.0,
+        iv,
+    ) {
+        Ok(result) => Ok(ResBatchItem {
+            operation: Some(Operation::Encrypt),
+            unique_batch_item_id: batch_item.unique_batch_item_id().cloned(),
+            result_status: ResultStatus::Success,
+            result_reason: None,
+            result_message: None,
+            payload: Some(ResponsePayload::Encrypt(EncryptResponsePayload {
+                unique_identifier: id.clone(),
+                data: result.ciphertext,
+                iv_counter_nonce: result.iv.map(IVOrCounterOrNonce::new),
+            })),
+            message_extension: None,
+        }),
+        Err(err) => Err((ResultReason::CryptographicFailure, err.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Integration tests would require a real PKCS#11 token
+}

--- a/src/kmip/operations/get_attributes.rs
+++ b/src/kmip/operations/get_attributes.rs
@@ -1,0 +1,51 @@
+use kmip::types::{
+    common::Operation,
+    request::{BatchItem, RequestPayload},
+    response::{
+        BatchItem as ResBatchItem, GetAttributesResponsePayload, ResponsePayload,
+        ResultReason, ResultStatus,
+    },
+};
+
+use crate::pkcs11::operations::get_attributes::get_key_attributes;
+use crate::pkcs11::pool::Pkcs11Connection;
+
+pub fn op(
+    pkcs11conn: Pkcs11Connection,
+    batch_item: &BatchItem,
+) -> Result<ResBatchItem, (ResultReason, String)> {
+    let RequestPayload::GetAttributes(unique_identifier, attribute_names) = batch_item.request_payload() else {
+        return Err((
+            ResultReason::InvalidMessage,
+            "Batch item payload is not a GetAttributes payload".to_string(),
+        ));
+    };
+
+    // UniqueIdentifier is required for this operation
+    let Some(id) = unique_identifier else {
+        return Err((
+            ResultReason::InvalidMessage,
+            "GetAttributes requires a UniqueIdentifier".to_string(),
+        ));
+    };
+
+    match get_key_attributes(pkcs11conn, id, attribute_names.as_ref()) {
+        Ok(attributes) => Ok(ResBatchItem {
+            operation: Some(Operation::GetAttributes),
+            unique_batch_item_id: batch_item.unique_batch_item_id().cloned(),
+            result_status: ResultStatus::Success,
+            result_reason: None,
+            result_message: None,
+            payload: Some(ResponsePayload::GetAttributes(GetAttributesResponsePayload {
+                unique_identifier: id.clone(),
+                attributes: if attributes.is_empty() {
+                    None
+                } else {
+                    Some(attributes)
+                },
+            })),
+            message_extension: None,
+        }),
+        Err(err) => Err((ResultReason::ItemNotFound, err.to_string())),
+    }
+}

--- a/src/kmip/operations/mod.rs
+++ b/src/kmip/operations/mod.rs
@@ -1,7 +1,10 @@
 pub mod activate;
 pub mod create_key_pair;
+pub mod decrypt;
 pub mod discover_versions;
+pub mod encrypt;
 pub mod get;
+pub mod get_attributes;
 pub mod modify_attribute;
 pub mod query;
 pub mod sign;

--- a/src/kmip/util.rs
+++ b/src/kmip/util.rs
@@ -5,6 +5,7 @@ use kmip::types::{
     response::ProtocolVersion,
     response::{
         BatchItem as ResBatchItem, ResponseHeader, ResponseMessage, ResultReason, ResultStatus,
+        Timestamp,
     },
 };
 use log::error;
@@ -25,14 +26,12 @@ pub fn mk_response(batch_items: Vec<ResBatchItem>) -> Vec<u8> {
     let epoch_time_now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
-        .as_secs()
-        .try_into()
-        .unwrap();
+        .as_secs();
 
     let mut res = ResponseMessage {
         header: ResponseHeader {
             protocol_version: ProtocolVersion { major: 1, minor: 2 },
-            timestamp: epoch_time_now,
+            timestamp: Timestamp::from_u64(epoch_time_now),
             batch_count: batch_items.len().try_into().unwrap(),
         },
         batch_items,

--- a/src/pkcs11/error.rs
+++ b/src/pkcs11/error.rs
@@ -82,6 +82,21 @@ impl Error {
     pub fn unsupported_cryptographic_parameters(err: impl ToString) -> Self {
         Self::UnsupportedCryptographicParameters(err.to_string())
     }
+
+    /// Create an error for unsupported operations or features.
+    pub fn not_supported(what: &str) -> Self {
+        Self::UnsupportedCryptographicParameters(format!("{} is not supported", what))
+    }
+
+    /// Create an error for internal failures.
+    pub fn internal(msg: &str) -> Self {
+        Self::UnusableConfig(format!("Internal error: {}", msg))
+    }
+
+    /// Create an error for invalid parameters.
+    pub fn invalid_param(msg: &str) -> Self {
+        Self::MalformedDataReceived(msg.to_string())
+    }
 }
 
 impl From<cryptoki::error::Error> for Error {

--- a/src/pkcs11/operations/decrypt.rs
+++ b/src/pkcs11/operations/decrypt.rs
@@ -1,0 +1,98 @@
+use cryptoki::mechanism::Mechanism;
+use cryptoki::object::{Attribute, AttributeType};
+use kmip::types::common::{CryptographicParameters, UniqueIdentifier};
+use log::{debug, info};
+
+use crate::pkcs11::error::Error;
+use crate::pkcs11::pool::Pkcs11Connection;
+
+/// AES block size in bytes
+const AES_BLOCK_SIZE: usize = 16;
+
+/// Decrypt data using a key identified by its label (UniqueIdentifier).
+///
+/// This implements KMIP Decrypt operation by translating to PKCS#11 C_Decrypt.
+/// Uses AES-CBC with PKCS#7 padding for compatibility with SoftHSM.
+pub fn decrypt_data(
+    pkcs11conn: Pkcs11Connection,
+    id: &UniqueIdentifier,
+    _crypto_params: Option<&CryptographicParameters>,
+    ciphertext: &[u8],
+    iv: Option<&[u8]>,
+) -> Result<Vec<u8>, Error> {
+    let label = id.0.as_str();
+    info!("Decrypting data with key label: {}", label);
+
+    // Find key by label (CKA_LABEL)
+    let handles = pkcs11conn
+        .session()
+        .find_objects(&[Attribute::Label(label.as_bytes().to_vec())])?;
+
+    if handles.is_empty() {
+        return Err(Error::not_found("Key", "label", label));
+    }
+
+    let key_handle = handles[0];
+    debug!("Found decryption key handle: {:?}", key_handle);
+
+    // Get key type to verify it's AES
+    let attrs = pkcs11conn.session().get_attributes(
+        key_handle,
+        &[AttributeType::KeyType],
+    )?;
+
+    let key_type = attrs
+        .iter()
+        .find_map(|a| {
+            if let Attribute::KeyType(kt) = a {
+                Some(*kt)
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| Error::internal("Key has no KeyType attribute"))?;
+
+    if key_type != cryptoki::object::KeyType::AES {
+        return Err(Error::not_supported(&format!(
+            "Key type {:?} for decryption",
+            key_type
+        )));
+    }
+
+    // IV is required for CBC decryption
+    let Some(iv_slice) = iv else {
+        return Err(Error::invalid_param("IV is required for AES-CBC decryption"));
+    };
+
+    // Convert IV to fixed-size array for CBC
+    // Note: OpenBao sends 12-byte IVs (GCM style), so we pad to 16 bytes for CBC
+    let mut iv_bytes = [0u8; AES_BLOCK_SIZE];
+    if iv_slice.len() >= AES_BLOCK_SIZE {
+        // Use first 16 bytes if longer
+        iv_bytes.copy_from_slice(&iv_slice[..AES_BLOCK_SIZE]);
+    } else {
+        // Pad shorter IVs (like 12-byte GCM IVs) with zeros
+        iv_bytes[..iv_slice.len()].copy_from_slice(iv_slice);
+        // Remaining bytes are already zero from initialization
+    }
+
+    debug!("Padded {}-byte IV to 16 bytes for CBC", iv_slice.len());
+
+    debug!("Using AES-CBC-PAD with 16-byte IV for decryption");
+
+    // Use AES-CBC with PKCS#7 padding
+    let mechanism = Mechanism::AesCbcPad(iv_bytes);
+
+    // Perform decryption
+    let plaintext = pkcs11conn.session().decrypt(&mechanism, key_handle, ciphertext)?;
+
+    debug!("Decrypted {} bytes to {} bytes", ciphertext.len(), plaintext.len());
+
+    Ok(plaintext)
+}
+
+#[cfg(test)]
+mod tests {
+    // Integration tests would require a real PKCS#11 token
+    // Unit tests for helper functions can be added here
+}

--- a/src/pkcs11/operations/encrypt.rs
+++ b/src/pkcs11/operations/encrypt.rs
@@ -1,0 +1,121 @@
+use cryptoki::mechanism::Mechanism;
+use cryptoki::object::{Attribute, AttributeType};
+use kmip::types::common::{CryptographicParameters, UniqueIdentifier};
+use log::{debug, info};
+use rand::Rng;
+
+use crate::pkcs11::error::Error;
+use crate::pkcs11::pool::Pkcs11Connection;
+
+/// Result of encryption: ciphertext and optional IV
+pub struct EncryptResult {
+    pub ciphertext: Vec<u8>,
+    pub iv: Option<Vec<u8>>,
+}
+
+/// AES block size in bytes
+const AES_BLOCK_SIZE: usize = 16;
+
+/// Encrypt data using a key identified by its label (UniqueIdentifier).
+///
+/// This implements KMIP Encrypt operation by translating to PKCS#11 C_Encrypt.
+/// Uses AES-CBC with PKCS#7 padding for compatibility with SoftHSM.
+pub fn encrypt_data(
+    pkcs11conn: Pkcs11Connection,
+    id: &UniqueIdentifier,
+    _crypto_params: Option<&CryptographicParameters>,
+    plaintext: &[u8],
+    iv: Option<&[u8]>,
+) -> Result<EncryptResult, Error> {
+    let label = id.0.as_str();
+    info!("Encrypting data with key label: {}", label);
+
+    // Find key by label (CKA_LABEL)
+    let handles = pkcs11conn
+        .session()
+        .find_objects(&[Attribute::Label(label.as_bytes().to_vec())])?;
+
+    if handles.is_empty() {
+        return Err(Error::not_found("Key", "label", label));
+    }
+
+    let key_handle = handles[0];
+    debug!("Found encryption key handle: {:?}", key_handle);
+
+    // Get key type to verify it's AES
+    let attrs = pkcs11conn.session().get_attributes(
+        key_handle,
+        &[AttributeType::KeyType],
+    )?;
+
+    let key_type = attrs
+        .iter()
+        .find_map(|a| {
+            if let Attribute::KeyType(kt) = a {
+                Some(*kt)
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| Error::internal("Key has no KeyType attribute"))?;
+
+    if key_type != cryptoki::object::KeyType::AES {
+        return Err(Error::not_supported(&format!(
+            "Key type {:?} for encryption",
+            key_type
+        )));
+    }
+
+    // Prepare IV - either use provided or generate random 16-byte IV for CBC
+    // Note: OpenBao sends 12-byte IVs (GCM style), so we pad to 16 bytes for CBC
+    let iv_bytes: [u8; AES_BLOCK_SIZE] = match iv {
+        Some(provided_iv) => {
+            let mut arr = [0u8; AES_BLOCK_SIZE];
+            if provided_iv.len() >= AES_BLOCK_SIZE {
+                // Use first 16 bytes if longer
+                arr.copy_from_slice(&provided_iv[..AES_BLOCK_SIZE]);
+            } else {
+                // Pad shorter IVs (like 12-byte GCM IVs) with zeros
+                arr[..provided_iv.len()].copy_from_slice(provided_iv);
+                // Remaining bytes are already zero from initialization
+            }
+            arr
+        }
+        None => {
+            let mut rng = rand::rng();
+            let mut random_iv = [0u8; AES_BLOCK_SIZE];
+            rng.fill(&mut random_iv[..]);
+            random_iv
+        }
+    };
+
+    debug!("Using AES-CBC-PAD with 16-byte IV");
+
+    // Use AES-CBC with PKCS#7 padding - handles arbitrary length data
+    let mechanism = Mechanism::AesCbcPad(iv_bytes);
+
+    // Perform encryption
+    let ciphertext = pkcs11conn.session().encrypt(&mechanism, key_handle, plaintext)?;
+
+    debug!("Encrypted {} bytes to {} bytes", plaintext.len(), ciphertext.len());
+
+    Ok(EncryptResult {
+        ciphertext,
+        iv: Some(iv_bytes.to_vec()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encrypt_result_structure() {
+        let result = EncryptResult {
+            ciphertext: vec![1, 2, 3, 4],
+            iv: Some(vec![5, 6, 7, 8]),
+        };
+        assert_eq!(result.ciphertext.len(), 4);
+        assert!(result.iv.is_some());
+    }
+}

--- a/src/pkcs11/operations/get_attributes.rs
+++ b/src/pkcs11/operations/get_attributes.rs
@@ -1,0 +1,144 @@
+use cryptoki::object::{Attribute, AttributeType, KeyType, ObjectClass};
+#[allow(unused_imports)]
+use kmip::types::common::{
+    AttributeName, AttributeValue, CryptographicAlgorithm, ObjectType, State, UniqueIdentifier,
+};
+use kmip::types::response::Attribute as KmipAttribute;
+use log::{debug, info};
+
+use crate::pkcs11::error::Error;
+use crate::pkcs11::pool::Pkcs11Connection;
+
+/// Get attributes for a key identified by its label (UniqueIdentifier).
+///
+/// This is used by OpenBao's KMIP seal to verify the key exists and is usable.
+/// OpenBao sends the key label as the UniqueIdentifier (e.g., "openbao-seal-key").
+pub fn get_key_attributes(
+    pkcs11conn: Pkcs11Connection,
+    id: &UniqueIdentifier,
+    requested_attributes: Option<&Vec<AttributeName>>,
+) -> Result<Vec<KmipAttribute>, Error> {
+    // Find key by label (CKA_LABEL)
+    let label = id.0.as_str();
+    info!("Looking up key by label: {}", label);
+
+    // Search for the key by label
+    let handles = pkcs11conn
+        .session()
+        .find_objects(&[Attribute::Label(label.as_bytes().to_vec())])?;
+
+    if handles.is_empty() {
+        return Err(Error::not_found("Key", "label", label));
+    }
+
+    let key_handle = handles[0];
+    debug!("Found key handle: {:?}", key_handle);
+
+    // Get key attributes from PKCS#11
+    let attrs = pkcs11conn.session().get_attributes(
+        key_handle,
+        &[
+            AttributeType::Class,
+            AttributeType::KeyType,
+            AttributeType::ValueLen,
+            AttributeType::Label,
+        ],
+    )?;
+
+    let mut object_type = None;
+    let mut crypto_algorithm = None;
+    let mut crypto_length: Option<i32> = None;
+
+    for attr in attrs {
+        match attr {
+            Attribute::Class(class) => {
+                object_type = match class {
+                    ObjectClass::SECRET_KEY => Some(ObjectType::SymmetricKey),
+                    ObjectClass::PUBLIC_KEY => Some(ObjectType::PublicKey),
+                    ObjectClass::PRIVATE_KEY => Some(ObjectType::PrivateKey),
+                    _ => None,
+                };
+            }
+            Attribute::KeyType(kt) => {
+                crypto_algorithm = match kt {
+                    KeyType::AES => Some(CryptographicAlgorithm::AES),
+                    KeyType::RSA => Some(CryptographicAlgorithm::RSA),
+                    KeyType::EC => Some(CryptographicAlgorithm::ECDSA),
+                    KeyType::DES3 => Some(CryptographicAlgorithm::TRIPLE_DES),
+                    _ => None,
+                };
+            }
+            Attribute::ValueLen(len) => {
+                // PKCS#11 reports key length in bytes, KMIP uses bits
+                // Ulong needs to be converted via into()
+                let len_usize: usize = len.into();
+                crypto_length = Some((len_usize * 8) as i32);
+            }
+            _ => {}
+        }
+    }
+
+    // Build response attributes
+    let mut result = Vec::new();
+
+    // Helper to check if attribute is requested (or all if none specified)
+    let should_include = |name: &str| -> bool {
+        match requested_attributes {
+            None => true, // Return all if none specified
+            Some(names) if names.is_empty() => true,
+            Some(names) => names.iter().any(|n| n.0 == name),
+        }
+    };
+
+    // Note: ObjectType and CryptographicAlgorithm are commented out due to
+    // serialization issues with the "Transparent" serde annotation that
+    // produces TTLV that confuses some KMIP clients.
+    // TODO: Fix kmip-protocol's serde serialization for these variants.
+
+    // if should_include("Object Type") {
+    //     if let Some(ot) = object_type {
+    //         result.push(KmipAttribute {
+    //             name: AttributeName("Object Type".to_string()),
+    //             index: None,
+    //             value: AttributeValue::ObjectType(ot),
+    //         });
+    //     }
+    // }
+
+    // if should_include("Cryptographic Algorithm") {
+    //     if let Some(ca) = crypto_algorithm {
+    //         result.push(KmipAttribute {
+    //             name: AttributeName("Cryptographic Algorithm".to_string()),
+    //             index: None,
+    //             value: AttributeValue::CryptographicAlgorithm(ca),
+    //         });
+    //     }
+    // }
+
+    if should_include("Cryptographic Length") {
+        if let Some(cl) = crypto_length {
+            result.push(KmipAttribute {
+                name: AttributeName("Cryptographic Length".to_string()),
+                index: None,
+                value: AttributeValue::Integer(cl),
+            });
+        }
+    }
+
+    if should_include("State") {
+        // Keys in SoftHSM are always active once created
+        result.push(KmipAttribute {
+            name: AttributeName("State".to_string()),
+            index: None,
+            value: AttributeValue::State(State::Active),
+        });
+    }
+
+    // Log what we found for debugging
+    debug!(
+        "Key {} found: object_type={:?}, algorithm={:?}, length_bits={:?}",
+        label, object_type, crypto_algorithm, crypto_length
+    );
+    debug!("Returning {} attributes for key {}", result.len(), label);
+    Ok(result)
+}

--- a/src/pkcs11/operations/mod.rs
+++ b/src/pkcs11/operations/mod.rs
@@ -1,3 +1,6 @@
 pub mod create_key_pair;
+pub mod decrypt;
+pub mod encrypt;
 pub mod get;
+pub mod get_attributes;
 pub mod sign;


### PR DESCRIPTION
## TL;DR

- Adds GetAttributes, Encrypt, and Decrypt operations
- Adds default slot/PIN configuration for mTLS-only clients
- Switches to fast_scan for request parsing (handles TimeStamp)
- All new features are config-gated and disabled by default
- Successfully tested with OpenBao auto-unseal (and SoftHSM)

## Related

- **Depends on:** https://github.com/NLnetLabs/kmip-protocol/pull/42 (TimeStamp/Timestamp types, Encrypt/Decrypt operations)
- Currently references fork branch; update to upstream once PR #42 merges

## Summary

This PR adds support for [OpenBao KMIP seal](https://openbao.org/docs/configuration/seal/kmip/) integration.

### New Operations

- **GetAttributes**: Retrieve key metadata (required by OpenBao for key lookup)
- **Encrypt**: Encrypt data using HSM keys (config-gated, default: disabled)
- **Decrypt**: Decrypt data using HSM keys (config-gated, default: disabled)

### Configuration Options

```toml
# Default PKCS#11 slot for mTLS-only clients (OpenBao uses mTLS, not KMIP auth)
default_slot = "openbao-hsm"

# Default PIN (also via DEFAULT_HSM_PIN environment variable)
# default_pin = "..."  # Prefer env var for security

# Enable Encrypt/Decrypt operations (required for OpenBao auto-unseal)
enable_encrypt = true
enable_decrypt = true
```

### Request Parsing

- Switches from serde to fast_scan for KMIP request parsing
- Correctly handles optional TimeStamp field in request headers
- Required because OpenBao sends TimeStamp in KMIP requests

## Motivation

OpenBao's KMIP seal requires:
1. GetAttributes to look up keys by label
2. Encrypt/Decrypt for key wrapping during auto-unseal
3. Support for TimeStamp in request headers

## Note

- I am not a Rust developer or security expert
- Code was generated with assistance from Claude
- Effort was made to avoid breaking default upstream behavior

## Testing

- [x] Successfully tested vault auto-unseal locally with OpenBao, kmip2pkcs11, and SoftHSM
- [x] Retested after updating Cargo.toml to reference git branch instead of local path
- [x] All existing tests pass (`cargo test`)
- [x] Config parsing tests added

## Backwards Compatibility

This change is backwards compatible because:
- All new features are config-gated and **disabled by default**
- `enable_encrypt = false` (default)
- `enable_decrypt = false` (default)
- `default_slot` and `default_pin` are optional
- Existing behavior unchanged unless explicitly configured

## Security Considerations

### Default Credentials (`default_slot`, `default_pin`)

> **SECURITY NOTE**: When set, any client that passes TLS authentication can access
> this slot without providing KMIP-level credentials. Only use in single-tenant
> deployments where TLS client certificate verification is sufficient for access control.

### Encrypt/Decrypt Operations

Operations are disabled by default and must be explicitly enabled via config.
Recommend only enabling for trusted internal services like OpenBao.

---

## Cargo.lock Dependency Changes

### Updated Packages (all newer versions)

| Package | Old | New | Notes |
|---------|-----|-----|-------|
| anstream | 0.6.20 | 0.6.21 | Terminal output |
| anstyle | 1.0.11 | 1.0.13 | ANSI styling |
| anstyle-query | 1.1.4 | 1.1.5 | |
| anstyle-wincon | 3.0.10 | 3.0.11 | |
| aws-lc-rs | 1.13.3 | 1.15.2 | Crypto (ring backend) |
| aws-lc-sys | 0.30.0 | 0.35.0 | AWS-LC bindings |
| bb8 | 0.9.0 | 0.9.1 | Connection pool |
| bcder | 0.7.5 | 0.7.6 | BER/DER encoding |
| bitflags | 2.9.4 | 2.10.0 | |
| bumpalo | 3.19.0 | 3.19.1 | Allocator |
| bytes | 1.10.1 | 1.11.0 | |
| cc | 1.2.35 | 1.2.51 | C compiler |
| cfg-if | 1.0.3 | 1.0.4 | |
| chrono | 0.4.41 | 0.4.42 | DateTime |
| clap | 4.5.46 | 4.5.54 | CLI args |
| clap_builder | 4.5.46 | 4.5.54 | |
| clap_derive | 4.5.45 | 4.5.49 | |
| clap_lex | 0.7.5 | 0.7.6 | |
| cmake | 0.1.54 | 0.1.57 | |
| deranged | 0.5.3 | 0.5.5 | |
| errno | 0.3.13 | 0.3.14 | |
| find-msvc-tools | 0.1.0 | 0.1.6 | |
| getrandom | 0.3.3 | 0.3.4 | |
| hashbrown | 0.14.5 | 0.16.1 | HashMap impl |
| hostname | 0.4.1 | 0.4.2 | |
| iana-time-zone | 0.1.63 | 0.1.64 | |
| indexmap | 2.11.0 | 2.12.1 | |
| is_terminal_polyfill | 1.70.1 | 1.70.2 | |
| js-sys | 0.3.77 | 0.3.83 | WASM |
| libc | 0.2.175 | 0.2.179 | |
| libloading | 0.8.8 | 0.8.9 | Dynamic loading |
| lock_api | 0.4.13 | 0.4.14 | |
| log | 0.4.27 | 0.4.29 | |
| memchr | 2.7.5 | 2.7.6 | |
| mio | 1.0.4 | 1.1.1 | I/O |
| moka | 0.12.10 | 0.12.12 | Cache |
| once_cell_polyfill | 1.70.1 | 1.70.2 | |
| openssl | 0.10.73 | 0.10.75 | OpenSSL bindings |
| openssl-sys | 0.9.109 | 0.9.111 | |
| parking_lot | 0.12.4 | 0.12.5 | Mutex |
| parking_lot_core | 0.9.11 | 0.9.12 | |
| pem | 3.0.5 | 3.0.6 | PEM encoding |
| portable-atomic | 1.11.1 | 1.13.0 | |
| proc-macro2 | 1.0.101 | 1.0.105 | |
| quote | 1.0.40 | 1.0.43 | |
| rcgen | 0.14.3 | 0.14.6 | Cert generation |
| redox_syscall | 0.5.17 | 0.5.18 | |
| ring | 0.17.14 | 0.17.14 | Crypto (unchanged) |
| rustls | 0.23.31 | 0.23.36 | TLS |
| rustls-pki-types | 1.12.0 | 1.13.2 | |
| rustls-webpki | 0.103.4 | 0.103.8 | |
| semver | 1.0.26 | 1.0.27 | |
| serde | 1.0.219 | 1.0.228 | Serialization |
| serde_bytes | 0.11.17 | 0.11.19 | |
| serde_derive | 1.0.219 | 1.0.228 | |
| serde_spanned | 1.0.0 | 1.0.4 | |
| signal-hook-registry | 1.4.6 | 1.4.8 | |
| socket2 | 0.6.0 | 0.6.1 | |
| syn | 2.0.106 | 2.0.113 | |
| thiserror | 1.0.69 | 2.0.17 | Error handling |
| thiserror-impl | 1.0.69 | 2.0.17 | |
| time | 0.3.42 | 0.3.44 | |
| time-core | 0.1.5 | 0.1.6 | |
| time-macros | 0.2.23 | 0.2.24 | |
| tokio | 1.47.1 | 1.49.0 | Async runtime |
| tokio-macros | 2.5.0 | 2.6.0 | |
| toml | 0.9.5 | 0.9.10 | Config parsing |
| toml_datetime | 0.7.0 | 0.7.5 | |
| toml_edit | 0.23.4 | 0.23.10 | |
| toml_parser | 1.0.2 | 1.0.6 | |
| toml_writer | 1.0.2 | 1.0.6 | |
| tracing | 0.1.41 | 0.1.44 | |
| tracing-attributes | 0.1.30 | 0.1.31 | |
| tracing-core | 0.1.34 | 0.1.36 | |
| unicode-ident | 1.0.18 | 1.0.22 | |
| untrusted | 0.9.0 | 0.9.0 | (unchanged) |
| uuid | 1.18.1 | 1.19.0 | |
| wasm-bindgen | 0.2.100 | 0.2.106 | |
| wasm-bindgen-macro | 0.2.100 | 0.2.106 | |
| wasm-bindgen-macro-support | 0.2.100 | 0.2.106 | |
| wasm-bindgen-shared | 0.2.100 | 0.2.106 | |
| windows-* | various | +0.0.1 | Minor bumps |
| winnow | 0.7.13 | 0.7.14 | Parser |
| wit-bindgen | 0.45.0 | 0.46.0 | |
| zerocopy | 0.8.26 | 0.8.31 | |
| zerocopy-derive | 0.8.26 | 0.8.31 | |
| zeroize | 1.8.1 | 1.8.2 | Secure memory |

### New Packages

| Package | Version | Purpose | Security Evaluation |
|---------|---------|---------|---------------------|
| **asn1-rs** | 0.7.1 | ASN.1/DER parsing | Rusticata project, widely used in security tooling. Transitive dep of x509-parser. |
| **asn1-rs-derive** | 0.6.0 | Proc-macro for asn1-rs | Companion crate |
| **asn1-rs-impl** | 0.2.0 | Internal impl | Companion crate |
| **data-encoding** | 2.9.0 | Base64/hex encoding | Maintained, no unsafe, 47M downloads |
| **der-parser** | 10.0.0 | DER/BER parser | Rusticata project, used in network security tools |
| **displaydoc** | 0.2.5 | Display derive from doc comments | Simple proc-macro by yaahc, 62M downloads |
| **enum-ordinalize** | 4.3.2 | Enum ↔ integer conversion | Replaces enum-flags (kmip-protocol change) |
| **enum-ordinalize-derive** | 4.3.2 | Proc-macro companion | |
| **itoa** | 1.0.17 | Fast int→string | dtolnay crate, 300M+ downloads, audited |
| **num-bigint** | 0.4.6 | Arbitrary precision integers | rust-num project, used in cryptography |
| **num-integer** | 0.1.46 | Integer traits | rust-num project, stable |
| **oid-registry** | 0.8.1 | OID database for X.509 | Rusticata project |
| **rusticata-macros** | 4.1.0 | Parser helper macros | Rusticata project utilities |
| **serde_core** | 1.0.228 | Serde internals | Split from serde, same maintainer (dtolnay) |
| **synstructure** | 0.13.2 | Derive macro helper | dtolnay maintained, 100M+ downloads |
| **wasip2** | 1.0.1 | WASI preview 2 | Replaces wasi crate, official bytecode alliance |
| **webpki-roots** | 1.0.5 | Mozilla CA certificates | Replaces webpki, rustls ecosystem |
| **x509-parser** | 0.18.0 | X.509 certificate parsing | Rusticata project, pulled in by rcgen |

### Removed Packages (and why)

| Category | Packages | Reason |
|----------|----------|--------|
| **Debug/backtrace** | addr2line, adler2, backtrace, gimli, miniz_oxide, object, rustc-demangle | Not needed in release builds; newer deps don't require |
| **Bindgen** | bindgen, cexpr, clang-sys, glob, home, lazycell, prettyplease, rustc-hash, which | aws-lc-sys 0.35 uses pre-generated bindings |
| **Regex** | aho-corasick, regex, regex-automata, regex-syntax | Was used by tracing-subscriber (removed) |
| **Tracing extras** | matchers, nu-ansi-term, sharded-slab, thread_local, tracing-log, tracing-subscriber, valuable | Extra tracing features no longer pulled in |
| **Old TLS** | sct, spin, webpki | rustls 0.23 uses webpki-roots instead |
| **Platform-specific** | android-tzdata, io-uring, linux-raw-sys, rustix | Newer tokio/mio don't require these |
| **Async internals** | generator, loom, scoped-tls, slab | Async testing/runtime internals no longer needed |
| **Misc** | either, enum-flags, itertools, wasm-bindgen-backend, web-sys, windows, windows-* | Replaced or no longer needed by updated deps |