### PR TITLE
Enable clap `wrap_help` feature like Cascade.

### DIFF
--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-clap = { workspace = true, features = ["cargo", "derive"] }
+clap = { workspace = true, features = ["cargo", "derive", "wrap_help"] }
 daemonbase = { workspace = true }
 serde = { version = "1.0.219", features = ["derive"] }
 toml = "0.9.5"


### PR DESCRIPTION
Match the behaviour of the Cascade CLI by also enabling the Clap `wrap_help` feature.