### PR TITLE
Add `--lib-path` and `CASCADE_HSM_BRDIGE_PKCS11_LIB_PATH` support.

### DIFF
--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-clap = { workspace = true, features = ["cargo", "derive"] }
+clap = { workspace = true, features = ["cargo", "env", "derive"] }
 daemonbase = { workspace = true }
 serde = { version = "1.0.219", features = ["derive"] }
 toml = "0.9.5"

--- a/crates/cfg/src/args.rs
+++ b/crates/cfg/src/args.rs
@@ -13,16 +13,27 @@ use crate::v1::{LogLevel, LogTarget};
 
 pub struct Args {
     /// The configuration file to load.
-    pub config: PathBuf,
+    pub config: Option<PathBuf>,
 
     /// The minimum severity of messages to log.
+    ///
+    /// Overrides the `[daemon.log.level]` config setting.
     pub log_level: Option<LogLevel>,
 
     /// The target of log messages.
+    ///
+    /// Overrides the `[daemon.log.target]` config setting.
     pub log_target: Option<LogTarget>,
 
     /// Whether cascade-hsm-bridge should fork on startup.
+    ///
+    /// Overrides the `[daemon.daemonize]` config setting.
     pub daemonize: bool,
+
+    /// Path to the PKCS#11 library to load.
+    ///
+    /// Overrides the `[pkcs11.lib-path]` config setting.
+    pub pkcs11_lib_path: Option<PathBuf>,
 }
 
 impl Args {
@@ -35,7 +46,7 @@ impl Args {
                 .value_name("PATH")
                 .value_parser(ValueParser::new(PathBufValueParser::new()))
                 .value_hint(ValueHint::FilePath)
-                .required(true)
+                .required_unless_present("pkcs11-lib-path")
                 .help("The configuration file to load"),
             Arg::new("log_level")
                 .long("log-level")
@@ -53,6 +64,14 @@ impl Args {
                 .long("daemonize")
                 .action(clap::ArgAction::SetTrue)
                 .help("Whether cascade-hsm-bridge should fork on startup"),
+            Arg::new("pkcs11-lib-path")
+                .long("lib-path")
+                .value_name("PKCS11_LIB_PATH")
+                .env("CASCADE_HSM_BRIDGE_PKCS11_LIB_PATH")
+                .value_hint(ValueHint::FilePath)
+                .required(false)
+                .help("Path to the PKCS#11 library to load")
+                .long_help("Overrides the `[pkcs11.lib-path]` config setting"),
         ])
     }
 
@@ -61,11 +80,13 @@ impl Args {
         Self {
             config: matches
                 .get_one::<PathBuf>("config")
-                .map(|p| p.as_path().into())
-                .expect("The Clap required flag should have prevented this happening"),
+                .map(|p| p.as_path().into()),
             log_level: matches.get_one::<LogLevel>("log_level").copied(),
             log_target: matches.get_one::<LogTarget>("log_target").cloned(),
             daemonize: matches.get_flag("daemonize"),
+            pkcs11_lib_path: matches
+                .get_one::<String>("pkcs11-lib-path")
+                .map(|p| p.into()),
         }
     }
 
@@ -81,6 +102,9 @@ impl Args {
                 }
                 if self.daemonize {
                     config.daemon.daemonize = true;
+                }
+                if let Some(pkcs11_lib_path) = self.pkcs11_lib_path {
+                    config.pkcs11.lib_path = pkcs11_lib_path;
                 }
             }
         }

--- a/crates/cfg/src/lib.rs
+++ b/crates/cfg/src/lib.rs
@@ -35,6 +35,18 @@ impl Config {
         let toml_str = std::fs::read_to_string(path).unwrap();
         Self::from_toml(&toml_str, None::<PathBuf>).map_err(|err| err.to_string())
     }
+
+    /// Creates a configuration from defaults with the required settings set
+    /// from provided arguments.
+    pub fn new<P: Into<PathBuf>>(pkcs11_lib_path: P) -> Self {
+        Self::V1(v1::Config {
+            daemon: Default::default(),
+            pkcs11: v1::Pkcs11Config {
+                lib_path: pkcs11_lib_path.into(),
+            },
+            server: Default::default(),
+        })
+    }
 }
 
 impl From<v1::Config> for Config {

--- a/doc/manual/source/man/cascade-hsm-bridge.rst
+++ b/doc/manual/source/man/cascade-hsm-bridge.rst
@@ -33,8 +33,8 @@ Options
 
 .. option:: -c, --config <PATH>
 
-          The configuration file to load. Defaults to
-          ``/etc/cascade-hsm-bridge/config.toml``.
+          The configuration file to load. Required unless ``--lib-path``
+		  is specified.
 
 .. option:: --log-level <LEVEL>
 
@@ -54,6 +54,16 @@ Options
           the working directory to the root directory and as such influences
           where files are looked for. Use absolute path names in configuration
           to avoid ambiguities.
+
+.. option:: --lib-path
+
+          The PKCS#11 library file to load. If specified the ``--config`` file
+		  argument can be omitted in which case the default configuration settings
+		  will be used with the exception that the PKCS#11 file to load will be
+		  taken from the value of this command line argument.
+
+		  .. note:: You can also supply this command line argument value by seting
+		            the CASCADE_HSM_BRIDGE_PKCS11_LIB_PATH environment variable.`
 
 .. option:: -h, --help
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,9 +58,18 @@ fn main() -> Result<(), ExitError> {
     );
 
     // Load the config file.
-    let mut config = cascade_hsm_bridge_cfg::Config::from_file(&args.config)
-        .inspect_err(|err| error!("Invalid configuration file: {err}"))
-        .map_err(|_| Failed)?;
+    let mut config = match args.config {
+        Some(ref config_path) => cascade_hsm_bridge_cfg::Config::from_file(config_path)
+            .inspect_err(|err| error!("Invalid configuration file: {err}"))
+            .map_err(|_| Failed)?,
+        None => {
+            let pkcs11_lib_path = args
+                .pkcs11_lib_path
+                .as_ref()
+                .expect("The Clap flags should have prevented this from happening");
+            cascade_hsm_bridge_cfg::Config::new(pkcs11_lib_path)
+        }
+    };
 
     if matches.get_flag("check_config") {
         // The configuration was loaded successfully; stop now.


### PR DESCRIPTION
To allow Cascade-HSM-Bridge to be started without a configuration file by specifying the only required argument via CLI arg or environment variable value instead.