### PR TITLE
Show the config file path that could not be loaded (fixes #10)

### DIFF
--- a/crates/cfg/src/lib.rs
+++ b/crates/cfg/src/lib.rs
@@ -32,7 +32,12 @@ impl Config {
 
     /// Creates a configuration from a configuration file.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, String> {
-        let toml_str = std::fs::read_to_string(path).unwrap();
+        let toml_str = std::fs::read_to_string(&path).map_err(|err| {
+            format!(
+                "Unable to open config file '{}': {err}",
+                path.as_ref().display()
+            )
+        })?;
         Self::from_toml(&toml_str, None::<PathBuf>).map_err(|err| err.to_string())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,13 @@ impl From<pkcs11::error::Error> for ExitError {
     }
 }
 
-fn main() -> Result<(), ExitError> {
+fn main() {
+    if let Err(err) = _main() {
+        err.exit()
+    }
+}
+
+fn _main() -> Result<(), ExitError> {
     Logger::init_logging()?;
 
     // Parse command-line arguments.


### PR DESCRIPTION
And don't print `Error: ExitError(())` to the console, just set the exit code.